### PR TITLE
fix(compliance): replace banned legal language — escrow/disbursement …

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 The construction industry loses billions annually to payment disputes, draw fraud, and frozen funds. In a typical legacy scenario, a funder wires the full project amount to a contractor at deal start — when a dispute arises over one milestone, the entire capital freezes, halting work site-wide.
 
-Vektrum replaces bulk upfront transfers with **milestone-conditional escrow**: capital is held by Stripe at deal creation, and each tranche releases only after passing a **10-condition server-side release gate** plus an AI precondition. Every action — from status changes to Stripe transfers to admin overrides — is written to a **hash-chained, append-only audit log** that cannot be modified or deleted.
+Vektrum replaces bulk upfront transfers with **milestone-conditional payment authorization**: capital is held by Stripe at deal creation, and each tranche releases only after passing a **10-condition server-side release gate** plus an AI precondition. Every action — from status changes to Stripe transfers to admin overrides — is written to a **hash-chained, append-only audit log** that cannot be modified or deleted.
 
 ### Core guarantees
 
@@ -220,7 +220,7 @@ All 10 conditions are evaluated atomically in a single server call:
 |---|-----------|---------------|
 | 1 | **Milestone approved** | `milestone.status === 'approved'` |
 | 2 | **Protection ready** | `milestone.protection_status === 'ready_for_release'` |
-| 3 | **Sufficient funded balance** | Escrow balance ≥ milestone amount |
+| 3 | **Sufficient funded balance** | Funded balance ≥ milestone amount |
 | 4 | **Stripe payouts enabled** | `contractor.stripe_payouts_enabled === true` |
 | 5 | **Contractor onboarding complete** | `contractor.onboarding_complete === true` |
 | 6 | **No existing release** | No non-voided release row exists for this milestone |

--- a/docs/payment-rails.md
+++ b/docs/payment-rails.md
@@ -25,7 +25,7 @@ All pre-existing releases are backfilled with `execution_rail='stripe_connect'`.
 
 ## The invariant Vektrum preserves across both rails
 
-> **Vektrum governs disbursement. Vektrum never holds funds.**
+> **Vektrum governs authorization. Vektrum never holds funds.**
 
 For `stripe_connect`: funds are held in Stripe-managed accounts. Vektrum
 instructs Stripe when to transfer; Stripe controls movement.
@@ -216,7 +216,7 @@ by `GET /api/admin/ops/external-releases`:
 
 Claims that remain safe:
 
-- "Vektrum governs disbursement. Vektrum never holds funds."
+- "Vektrum governs authorization. Vektrum never holds funds."
 - "Funds are held in Stripe Connect managed accounts — not by Vektrum." (for
   Stripe-rail deals)
 - "Append-only, hash-chained audit log."

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -302,9 +302,12 @@ export default async function RootLayout({
               <p className="mt-1 text-[11px] text-white/60 leading-relaxed">
                 Vektrum is not a bank, lender, or money transmitter. Platform security reviewed annually. Data encrypted in transit and at rest.
               </p>
+              <p className="mt-1 text-[11px] text-white/55 leading-relaxed">
+                Vektrum is authorization software. Vektrum does not hold, move, or custody funds. All payments are executed by your licensed payment partner or financial institution.
+              </p>
               <div className="flex flex-col gap-1 sm:items-end">
                 <p className="text-[12px] text-white/65">
-                  Vektrum governs disbursement. Vektrum never holds funds.
+                  Vektrum governs authorization. Vektrum never holds funds.
                 </p>
                 {/* Removed footer attribution */}
               </div>


### PR DESCRIPTION
…→ authorization

Phase 1 surgical copy fixes:
- README.md: "milestone-conditional escrow" → "milestone-conditional payment authorization"; "Escrow balance" → "Funded balance"
- docs/payment-rails.md: "governs disbursement" → "governs authorization" (both instances)
- src/app/layout.tsx: add legal disclaimer footer line; update footer tagline to "governs authorization"

https://claude.ai/code/session_01F2xv8xaihb7x4omGvXCKtF