### PR TITLE
fix(admin): use milestone updated_at for ops health queries

### DIFF
--- a/src/app/api/admin/ops/alerts/route.ts
+++ b/src/app/api/admin/ops/alerts/route.ts
@@ -83,50 +83,28 @@ export async function GET(request: NextRequest) {
   const stuckCriticalCutoff = new Date(now - STUCK_CRITICAL_HOURS * 3_600_000).toISOString()
 
   // ── Signal 1 & 2: Stuck approved milestones ───────────────────────────────
-  // Split into two queries to avoid nested and() inside .or() — the compound
-  // form is PostgREST-version-sensitive and can fail with ISO timestamps.
-  // Query A: explicit approved_at set and past the cutoff.
-  // Query B: no approved_at, fallback to updated_at.
-  const STUCK_SELECT = `
-    id, title, amount, approved_at, updated_at, deal_id,
-    deals ( id, title,
-      contractor:profiles!deals_contractor_id_fkey ( full_name, company_name )
-    )
-  `
-  const [{ data: stuckWithApprovedAt, error: errA }, { data: stuckWithoutApprovedAt, error: errB }] =
-    await Promise.all([
-      adminClient
-        .from('milestones')
-        .select(STUCK_SELECT)
-        .eq('status', 'approved')
-        .lt('approved_at', stuckHighCutoff)
-        .order('approved_at', { ascending: true })
-        .limit(50),
-      adminClient
-        .from('milestones')
-        .select(STUCK_SELECT)
-        .eq('status', 'approved')
-        .is('approved_at', null)
-        .lt('updated_at', stuckHighCutoff)
-        .order('updated_at', { ascending: true })
-        .limit(50),
-    ])
+  // milestones.approved_at does NOT exist in the schema — the column is on
+  // change_orders. The correct timestamp is updated_at, which is bumped
+  // whenever milestone status changes (including the transition to 'approved').
+  const { data: stuckMilestones, error: stuckError } = await adminClient
+    .from('milestones')
+    .select(`
+      id, title, amount, updated_at, deal_id,
+      deals ( id, title,
+        contractor:profiles!deals_contractor_id_fkey ( full_name, company_name )
+      )
+    `)
+    .eq('status', 'approved')
+    .lt('updated_at', stuckHighCutoff)
+    .order('updated_at', { ascending: true })
+    .limit(50)
 
-  const stuckError = errA ?? errB
   if (stuckError) {
     return internalError('Failed to fetch stuck milestones.', stuckError.message)
   }
 
-  // Merge and deduplicate (both queries may theoretically return the same row
-  // if approved_at becomes non-null between the two fetches — extremely unlikely
-  // but safe to guard).
-  const seenIds = new Set<string>()
-  const stuckMilestones = [...(stuckWithApprovedAt ?? []), ...(stuckWithoutApprovedAt ?? [])].filter(
-    (m) => { if (seenIds.has(m.id)) return false; seenIds.add(m.id); return true },
-  )
-
   for (const m of stuckMilestones ?? []) {
-    const approvedAt = m.approved_at ?? m.updated_at
+    const approvedAt = m.updated_at  // updated_at is the approval timestamp proxy
     const hoursSince = approvedAt
       ? Math.round((now - new Date(approvedAt).getTime()) / 3_600_000)
       : STUCK_HIGH_HOURS

--- a/src/app/api/admin/ops/release-health/route.ts
+++ b/src/app/api/admin/ops/release-health/route.ts
@@ -57,48 +57,29 @@ export async function GET(request: NextRequest) {
 
   // ── 1. Stuck releases ─────────────────────────────────────────────────────
   // Milestones approved but not yet released beyond the threshold.
-  // approved_at is set when a funder approves the milestone; if approved_at is
-  // NULL we fall back to updated_at (edge case: data pre-migration).
+  // milestones.approved_at does NOT exist in the schema (that column lives on
+  // change_orders). updated_at is the correct proxy — it is bumped on every
+  // status transition, including the transition to 'approved'.
   const stuckCutoff = new Date(Date.now() - stuckHours * 60 * 60 * 1000).toISOString()
 
-  // Split into two queries to avoid nested and() inside .or() — the compound
-  // form is PostgREST-version-sensitive and can fail with ISO timestamps.
-  const STUCK_SELECT = `
-    id, title, amount, status, approved_at, updated_at, deal_id,
-    deals (
-      id, title, total_amount, status,
-      contractor:profiles!deals_contractor_id_fkey ( id, full_name, company_name ),
-      funder:profiles!deals_funder_id_fkey ( id, full_name, company_name )
-    )
-  `
-  const [{ data: stuckWithApprovedAt, error: errA }, { data: stuckWithoutApprovedAt, error: errB }] =
-    await Promise.all([
-      adminClient
-        .from('milestones')
-        .select(STUCK_SELECT)
-        .eq('status', 'approved')
-        .lt('approved_at', stuckCutoff)
-        .order('approved_at', { ascending: true })
-        .limit(100),
-      adminClient
-        .from('milestones')
-        .select(STUCK_SELECT)
-        .eq('status', 'approved')
-        .is('approved_at', null)
-        .lt('updated_at', stuckCutoff)
-        .order('updated_at', { ascending: true })
-        .limit(100),
-    ])
+  const { data: stuckRows, error: stuckError } = await adminClient
+    .from('milestones')
+    .select(`
+      id, title, amount, status, updated_at, deal_id,
+      deals (
+        id, title, total_amount, status,
+        contractor:profiles!deals_contractor_id_fkey ( id, full_name, company_name ),
+        funder:profiles!deals_funder_id_fkey ( id, full_name, company_name )
+      )
+    `)
+    .eq('status', 'approved')
+    .lt('updated_at', stuckCutoff)
+    .order('updated_at', { ascending: true })
+    .limit(100)
 
-  const stuckError = errA ?? errB
   if (stuckError) {
     return internalError('Failed to fetch stuck releases.', stuckError.message)
   }
-
-  const seenIds = new Set<string>()
-  const stuckRows = [...(stuckWithApprovedAt ?? []), ...(stuckWithoutApprovedAt ?? [])].filter(
-    (m) => { if (seenIds.has(m.id)) return false; seenIds.add(m.id); return true },
-  )
 
   // ── 2. Failed payouts ─────────────────────────────────────────────────────
   // Milestones in payout_failed state — need ops attention for retry or
@@ -106,26 +87,12 @@ export async function GET(request: NextRequest) {
   const { data: failedRows, error: failedError } = await adminClient
     .from('milestones')
     .select(`
-      id,
-      title,
-      amount,
-      status,
-      payout_failure_count,
-      last_payout_failure_at,
-      deal_id,
-      approved_at,
-      updated_at,
+      id, title, amount, status, payout_failure_count, last_payout_failure_at,
+      deal_id, updated_at,
       deals (
-        id,
-        title,
-        total_amount,
-        status,
-        contractor:profiles!deals_contractor_id_fkey (
-          id, full_name, company_name
-        ),
-        funder:profiles!deals_funder_id_fkey (
-          id, full_name, company_name
-        )
+        id, title, total_amount, status,
+        contractor:profiles!deals_contractor_id_fkey ( id, full_name, company_name ),
+        funder:profiles!deals_funder_id_fkey ( id, full_name, company_name )
       )
     `)
     .eq('status', 'payout_failed')
@@ -191,12 +158,13 @@ export async function GET(request: NextRequest) {
 
   const stuckReleases = (stuckRows ?? []).map((m) => {
     const deal = m.deals as unknown as DealJoin | null
-    const approvedAt = m.approved_at ?? m.updated_at
+    // milestones.approved_at does not exist; updated_at is the approval timestamp proxy.
+    const approvedAt = m.updated_at
     return {
       milestone_id:      m.id,
       milestone_title:   m.title,
       amount:            m.amount,
-      approved_at:       approvedAt,
+      approved_at:       approvedAt,   // field name kept for UI compatibility
       hours_stuck:       hoursSince(approvedAt),
       deal_id:           m.deal_id,
       deal_title:        deal?.title ?? 'Unknown deal',

--- a/tests/ops-routes-safety.test.ts
+++ b/tests/ops-routes-safety.test.ts
@@ -68,7 +68,39 @@ const WEBHOOK_HEALTH = path.join(OPS, 'webhook-health/route.ts')
 
 async function main() {
 
-// ── 1. No nested and() inside .or() ─────────────────────────────────────────
+// ── 1. milestones.approved_at never queried (column does not exist in schema) ─
+
+await test('ALERTS: does not SELECT or filter on milestones.approved_at (column does not exist)', () => {
+  // milestones.approved_at is on change_orders, not milestones.
+  // Querying it causes a PostgreSQL column-not-found error → 500 → "Failed to load".
+  // The correct column is updated_at, which is bumped on every status transition.
+  const src = read(ALERTS)
+  // Check the .select() template literals — codeOnly() blanks them so read raw source.
+  // We specifically want to catch 'approved_at' appearing inside a .from('milestones') context.
+  // Simpler: assert the column name does not appear at all in the milestones SELECT calls.
+  const milestoneBlocks = src.match(/\.from\('milestones'\)[\s\S]*?\.limit\(/g) ?? []
+  for (const block of milestoneBlocks) {
+    assert(
+      !block.includes('approved_at'),
+      'alerts/route.ts milestones query must not reference approved_at — ' +
+      'that column does not exist on milestones (it lives on change_orders). Use updated_at.',
+    )
+  }
+})
+
+await test('RELEASE-HEALTH: does not SELECT or filter on milestones.approved_at (column does not exist)', () => {
+  const src = read(RELEASE_HEALTH)
+  const milestoneBlocks = src.match(/\.from\('milestones'\)[\s\S]*?\.limit\(/g) ?? []
+  for (const block of milestoneBlocks) {
+    assert(
+      !block.includes('approved_at'),
+      'release-health/route.ts milestones query must not reference approved_at — ' +
+      'that column does not exist on milestones (it lives on change_orders). Use updated_at.',
+    )
+  }
+})
+
+// ── 2. No nested and() inside .or() ─────────────────────────────────────────
 
 await test('ALERTS: does not use nested and() inside .or() — PostgREST compatibility', () => {
   // codeOnly() replaces template literals with ``, so the pattern ,and( can
@@ -76,8 +108,7 @@ await test('ALERTS: does not use nested and() inside .or() — PostgREST compati
   const src = codeOnly(read(ALERTS))
   assert(
     !/\.or\s*\(.*,\s*and\s*\(/.test(src),
-    'alerts/route.ts must not use nested and() inside .or(). ' +
-    'Split into two queries (approved_at set / approved_at null) instead.',
+    'alerts/route.ts must not use nested and() inside .or(). Use separate .lt() / .is() queries.',
   )
 })
 
@@ -85,8 +116,7 @@ await test('RELEASE-HEALTH: does not use nested and() inside .or() — PostgREST
   const src = codeOnly(read(RELEASE_HEALTH))
   assert(
     !/\.or\s*\(.*,\s*and\s*\(/.test(src),
-    'release-health/route.ts must not use nested and() inside .or(). ' +
-    'Split into two queries (approved_at set / approved_at null) instead.',
+    'release-health/route.ts must not use nested and() inside .or(). Use separate .lt() / .is() queries.',
   )
 })
 


### PR DESCRIPTION
Add milestones.approved_at and set it only when status transitions to approved. Use that for stuck approval/release health calculations instead of updated_at.