### PR TITLE
fix(contracts): allow funders to send contract envelopes

### DIFF
--- a/src/app/api/deals/[dealId]/contract/send-envelope/route.ts
+++ b/src/app/api/deals/[dealId]/contract/send-envelope/route.ts
@@ -18,7 +18,10 @@ export const dynamic = 'force-dynamic'
 //   - Active non-voided contract exists for the deal with no envelope_id yet
 //   - Both contractor and funder are assigned to the deal
 //
-// Auth: contractor or admin (funder signs but does not initiate)
+// Auth: contractor, funder, or admin
+//   Funders are authorized to initiate signing in funder-led workflows where
+//   the funder uploads the governing contract. Funder identity is verified:
+//   the authenticated user must match deal.funder_id.
 //
 // Does NOT create a fake or internal signature — all signing happens in DocuSign.
 
@@ -37,9 +40,9 @@ export async function POST(
 
   const { user, profile } = authContext
 
-  if (profile.role !== 'contractor' && profile.role !== 'admin') {
+  if (profile.role !== 'contractor' && profile.role !== 'admin' && profile.role !== 'funder') {
     return NextResponse.json(
-      { error: 'Only the contractor or an admin can send the contract for signing.' },
+      { error: 'Only the funder, contractor, or admin can send the contract for signing.' },
       { status: 403 },
     )
   }
@@ -66,6 +69,15 @@ export async function POST(
   if (profile.role === 'contractor' && deal.contractor_id !== user.id) {
     return NextResponse.json(
       { error: 'You are not the contractor on this deal.' },
+      { status: 403 },
+    )
+  }
+
+  // Funder identity check: the authenticated funder must be assigned to this deal.
+  // Prevents an unrelated funder from sending envelopes on deals they do not own.
+  if (profile.role === 'funder' && deal.funder_id !== user.id) {
+    return NextResponse.json(
+      { error: 'You are not the funder on this deal.' },
       { status: 403 },
     )
   }

--- a/src/components/deal/contract-signing-section.tsx
+++ b/src/components/deal/contract-signing-section.tsx
@@ -57,7 +57,9 @@ export function ContractSigningSection({
   const waitingOnContractor = isFunder     && funderDone && !contractorDone
 
   // Primary action visibility
-  const showSendEnvelope = !localEnvelopeId && (isContractor || isAdmin)
+  // Funders are authorized to initiate signing in funder-led workflows where
+  // the funder uploads the governing contract or funding document.
+  const showSendEnvelope = !localEnvelopeId && (isContractor || isAdmin || isFunder)
   const showOpenDocuSign = !!localEnvelopeId && (funderTurn || contractorTurn)
 
   // ── Actions ─────────────────────────────────────────────────────────────────
@@ -156,9 +158,17 @@ export function ContractSigningSection({
             </span>
           </div>
         ) : (
-          <div className="flex items-center gap-1.5 text-[11px] text-amber-400/60">
-            <AlertCircle size={11} aria-hidden="true" />
-            <span>No DocuSign envelope — signature request not yet sent</span>
+          <div className="rounded-lg border border-amber-500/20 bg-amber-500/[0.05] px-3 py-2.5 space-y-1">
+            <div className="flex items-center gap-1.5">
+              <AlertCircle size={11} className="text-amber-400/80 flex-shrink-0" aria-hidden="true" />
+              <span className="text-[11px] font-semibold text-amber-400/80">
+                Contract uploaded — signatures not sent
+              </span>
+            </div>
+            <p className="text-[11px] text-white/40 leading-relaxed">
+              This contract has been added to the deal, but no signature request has been sent yet.
+              Milestone releases remain blocked until the required parties complete signing.
+            </p>
           </div>
         )}
 
@@ -176,7 +186,7 @@ export function ContractSigningSection({
         {/* Primary actions */}
         <div className="flex flex-col gap-2.5">
 
-          {/* Contractor / admin: send envelope when none exists */}
+          {/* Funder / contractor / admin: send envelope when none exists */}
           {showSendEnvelope && (
             <button
               type="button"
@@ -222,13 +232,6 @@ export function ContractSigningSection({
               <Clock size={13} className="text-amber-400/70 flex-shrink-0" aria-hidden="true" />
               You have signed. Waiting for the contractor to sign.
             </div>
-          )}
-
-          {/* Funder: no envelope yet — contractor initiates */}
-          {!localEnvelopeId && isFunder && (
-            <p className="text-[12px] text-white/40">
-              The contractor will send the contract for signatures.
-            </p>
           )}
 
           {/* Admin: read-only view */}

--- a/tests/docusign-contract-surface.test.ts
+++ b/tests/docusign-contract-surface.test.ts
@@ -12,7 +12,7 @@
  *  6.  "Contract executed" (signed) state is handled by server-rendered section
  *  7.  send-envelope route file exists
  *  8.  send-envelope route uses existing DocuSign createEnvelope (not fake)
- *  9.  send-envelope route rejects admins/funders from sending (contractor/admin only)
+ *  9.  send-envelope route allows contractor, funder, and admin to send
  * 10.  send-envelope route downloads PDF from storage before calling DocuSign
  * 11.  send-envelope route saves envelope_id back to contracts table
  * 12.  send-envelope route audit-logs docusign_envelope_sent
@@ -29,6 +29,11 @@
  * 23.  DocuSign webhook route is unchanged
  * 24.  Contract upload route (ContractUploadSection) is unchanged
  * 25.  package.json wires this test file into npm test
+ * 26.  send-envelope API includes funder in allowed roles + funder_id identity check
+ * 27.  send-envelope API rejects unrelated funder (funder_id !== user.id guard present)
+ * 28.  UI showSendEnvelope includes isFunder (all three roles can send)
+ * 29.  UI no longer says "The contractor will send the contract for signatures"
+ * 30.  UI shows "Contract uploaded — signatures not sent" when no envelope exists
  *
  * Run: npx tsx tests/docusign-contract-surface.test.ts
  */
@@ -132,11 +137,12 @@ async function main() {
     '8b. send-envelope imports from DocuSign engine module',
   )
 
-  // ── 9. Role check — contractor or admin only ──────────────────────────────────
+  // ── 9. Role check — contractor, funder, or admin ──────────────────────────────
   check(
     sendEnv.includes("profile.role !== 'contractor'") &&
-    sendEnv.includes("profile.role !== 'admin'"),
-    '9. send-envelope rejects non-contractor/admin roles (funder cannot initiate)',
+    sendEnv.includes("profile.role !== 'admin'") &&
+    sendEnv.includes("profile.role !== 'funder'"),
+    '9. send-envelope allows contractor, funder, and admin (all three in role check)',
   )
 
   // ── 10. Downloads PDF from storage ────────────────────────────────────────────
@@ -273,6 +279,54 @@ async function main() {
   check(
     pkg.includes('docusign-contract-surface.test.ts'),
     '25. This test file is wired into npm test in package.json',
+  )
+
+  // ── 26. send-envelope API allows funder + funder_id identity check ────────────
+  check(
+    sendEnv.includes("profile.role !== 'funder'"),
+    '26. send-envelope role check includes funder in allowed roles',
+  )
+  check(
+    sendEnv.includes("role === 'funder'") && sendEnv.includes('funder_id') && sendEnv.includes('user.id'),
+    '26b. send-envelope has funder identity check (funder_id === user.id)',
+  )
+
+  // ── 27. send-envelope rejects unrelated funder ────────────────────────────────
+  // The funder identity check must gate on funder_id !== user.id to prevent a
+  // different funder from sending envelopes on a deal they are not assigned to.
+  check(
+    sendEnv.includes('funder_id !== user.id'),
+    '27. send-envelope rejects unrelated funder (funder_id !== user.id guard present)',
+  )
+
+  // ── 28. UI showSendEnvelope includes isFunder ─────────────────────────────────
+  check(
+    section.includes('isFunder') && section.includes('showSendEnvelope'),
+    '28. ContractSigningSection defines isFunder and showSendEnvelope',
+  )
+  check(
+    section.includes('isContractor || isAdmin || isFunder') ||
+    section.includes('isFunder || isContractor || isAdmin') ||
+    section.includes('isAdmin || isFunder') ||
+    (section.includes('showSendEnvelope') && section.includes('isFunder')),
+    '28b. showSendEnvelope includes isFunder so funder sees the send button',
+  )
+
+  // ── 29. UI no longer says "The contractor will send the contract" ─────────────
+  check(
+    !section.includes('The contractor will send the contract for signatures'),
+    '29. ContractSigningSection no longer tells funders the contractor will send the contract',
+  )
+
+  // ── 30. UI shows "Contract uploaded — signatures not sent" state ──────────────
+  check(
+    section.includes('Contract uploaded') && section.includes('signatures not sent'),
+    '30. ContractSigningSection shows "Contract uploaded — signatures not sent" when no envelope',
+  )
+  check(
+    section.includes('no signature request has been sent yet') ||
+    section.includes('signature request has been sent'),
+    '30b. ContractSigningSection explains that no signature request has been sent yet',
   )
 
   console.log('\n✓ All docusign-contract-surface tests passed.\n')


### PR DESCRIPTION
Funder/admin users see import-from-contract/funding-documents as the recommended path.

- Contractor users are guided to invite their funder or submit draft project info.

- Page copy makes clear: contractor submits, funder verifies/authorizes, Vektrum enforces, rail executes.

- The app does not imply contractors control release conditions.

- Existing create-deal behavior remains safe