### PR TITLE
fix(tests): update release-gate funder fixture with B1 Profile fields

### DIFF
--- a/tests/release-gate.test.ts
+++ b/tests/release-gate.test.ts
@@ -318,7 +318,10 @@ function funder(): Profile {
     stripe_account_id:     null,
     stripe_payouts_enabled: false,
     onboarding_complete:   true,
-    subscription_tier:     'standalone',    // required field on Profile
+    subscription_tier:     'standalone',
+    disbursement_rail:     'stripe',
+    mfa_enrolled:          true,
+    mfa_enrolled_at:       null,
     created_at:            new Date().toISOString(),
     updated_at:            new Date().toISOString(),
   }


### PR DESCRIPTION
B1 added disbursement_rail to the Profile type. The funder() test fixture was missing disbursement_rail, mfa_enrolled, and mfa_enrolled_at — causing a new TS2739 error. Added all three required fields.